### PR TITLE
Implement tool image management

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default nextConfig;

--- a/src/app/(toolsList)/components/ToolsImageManager.tsx
+++ b/src/app/(toolsList)/components/ToolsImageManager.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Image from "next/image";
+import { useRef } from "react";
+import useSWR from "swr";
+import { listToolImages, uploadToolImage, deleteToolImage } from "../services/toolImages";
+
+type Props = { asset: string };
+
+export default function ToolsImageManager({ asset }: Props) {
+  const { data: images = [], mutate } = useSWR(
+    asset ? ["tool-images", asset] : null,
+    () => listToolImages(asset)
+  );
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    await uploadToolImage(asset, file);
+    e.target.value = "";
+    mutate();
+  };
+
+  const handleDelete = async (name: string) => {
+    await deleteToolImage(asset, name);
+    mutate();
+  };
+
+  return (
+    <div>
+      <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+        {images.map((name: string) => (
+          <div key={name}>
+            <Image src={`/tool-images/${name}`} alt={name} width={150} height={150} />
+            <button onClick={() => handleDelete(name)}>Delete</button>
+          </div>
+        ))}
+      </div>
+      {images.length < 3 && (
+        <input
+          type="file"
+          accept="image/*"
+          ref={inputRef}
+          onChange={handleUpload}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(toolsList)/services/toolImages.ts
+++ b/src/app/(toolsList)/services/toolImages.ts
@@ -1,0 +1,20 @@
+import { http } from "@/services/http-service";
+
+export async function listToolImages(asset: string) {
+  const res = await http.get(`/toolsdata/${asset}/images`);
+  return res.data;
+}
+
+export async function uploadToolImage(asset: string, file: File) {
+  const formData = new FormData();
+  formData.append("file", file);
+  const res = await http.post(`/toolsdata/${asset}/images`, formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return res.data;
+}
+
+export async function deleteToolImage(asset: string, filename: string) {
+  const res = await http.delete(`/toolsdata/${asset}/images`, { params: { filename } });
+  return res.data;
+}

--- a/src/app/(toolsList)/toolsdata/[asset]/page.tsx
+++ b/src/app/(toolsList)/toolsdata/[asset]/page.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import prisma from "@/lib/db";
 import { Text, Title } from '@mantine/core';
 import ToolsCerDataEdit from '../../components/ToolsCerDataEdit';
+import ToolsImageManager from '../../components/ToolsImageManager';
 
 async function page({params,}: {params: Promise<{ asset : string }>}) {
   const { asset } = await params;
@@ -14,6 +15,7 @@ async function page({params,}: {params: Promise<{ asset : string }>}) {
       <Text>ครุภัณฑ์และเครื่องมือเครื่องใช้</Text>
       <Title >{`${tool.asset} ${tool.assetDescription}`}</Title>
       <ToolsCerDataEdit id={asset} />
+      <ToolsImageManager asset={asset} />
     </>
   )
 }

--- a/src/app/api/toolsdata/[asset]/images/route.ts
+++ b/src/app/api/toolsdata/[asset]/images/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest } from "next/server";
+import path from "path";
+import fs from "fs/promises";
+
+const IMAGE_DIR = path.join(process.cwd(), "public", "tool-images");
+
+export async function GET(request: NextRequest, { params }: { params: { asset: string } }) {
+  try {
+    const files = await fs.readdir(IMAGE_DIR);
+    const images = files.filter((name) => name.startsWith(`${params.asset}_`));
+    return new Response(JSON.stringify(images), { status: 200 });
+  } catch (error) {
+    console.error("Error listing images:", error);
+    return new Response("Failed to list images", { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest, { params }: { params: { asset: string } }) {
+  try {
+    const form = await request.formData();
+    const file = form.get("file") || form.get("image");
+    if (!file || !(file instanceof Blob)) {
+      return new Response("No file provided", { status: 400 });
+    }
+
+    await fs.mkdir(IMAGE_DIR, { recursive: true });
+    const files = await fs.readdir(IMAGE_DIR);
+    const existing = files.filter((name) => name.startsWith(`${params.asset}_`));
+    if (existing.length >= 3) {
+      return new Response("Image limit reached", { status: 400 });
+    }
+    const numbers = existing.map((n) => parseInt(n.split("_")[1]));
+    const next = [1, 2, 3].find((n) => !numbers.includes(n));
+    if (!next) {
+      return new Response("Image limit reached", { status: 400 });
+    }
+    const ext = (file as File).name.split('.').pop() || "jpg";
+    const filename = `${params.asset}_${String(next).padStart(2, "0")}.${ext}`;
+    const buffer = Buffer.from(await (file as File).arrayBuffer());
+    await fs.writeFile(path.join(IMAGE_DIR, filename), buffer);
+    return new Response(JSON.stringify({ filename }), { status: 200 });
+  } catch (error) {
+    console.error("Error uploading image:", error);
+    return new Response("Failed to upload", { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  try {
+    const filename = request.nextUrl.searchParams.get("filename");
+    if (!filename) return new Response("filename required", { status: 400 });
+    await fs.unlink(path.join(IMAGE_DIR, filename));
+    return new Response("deleted", { status: 200 });
+  } catch (error) {
+    console.error("Error deleting image:", error);
+    return new Response("Failed to delete", { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/tool-images` folder for storing tool photos
- allow listing, uploading and deleting tool images via new API route
- wrap API requests in `toolImages` helpers
- manage images from new `ToolsImageManager` component
- show image manager on tool data page
- configure Next.js to serve local images

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521bbcc6648323830c23b551745849