### PR TITLE
Fix Next.js build error for /emd

### DIFF
--- a/src/app/(toolsList)/emd/page.tsx
+++ b/src/app/(toolsList)/emd/page.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+
+export const dynamic = 'force-dynamic';
 import prisma from "@/lib/db";
 import TableCostCtr from '../components/TableCostCtr';
 import { CostCtr } from '@prisma/client';


### PR DESCRIPTION
## Summary
- mark the `/emd` page as dynamic so Next.js won't try to prerender it during build

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852553c4be88323b7c49d1673d263b6