### PR TITLE
Add endpoint to serve uploaded tool images

### DIFF
--- a/src/app/api/toolsdata/[asset]/images/[filename]/route.ts
+++ b/src/app/api/toolsdata/[asset]/images/[filename]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import path from "path";
+import fs from "fs/promises";
+
+const IMAGE_DIR = path.join(process.cwd(), "Upload");
+
+const MIME_TYPES: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+};
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { asset: string; filename: string } }
+) {
+  const { filename } = params;
+
+  try {
+    const filePath = path.join(IMAGE_DIR, filename);
+    const resolved = path.resolve(filePath);
+
+    if (!resolved.startsWith(IMAGE_DIR)) {
+      return new NextResponse("Invalid path", { status: 400 });
+    }
+
+    const data = await fs.readFile(resolved);
+    const ext = path.extname(filename).replace(".", "").toLowerCase();
+    const type = MIME_TYPES[ext] || "application/octet-stream";
+
+    return new NextResponse(data, {
+      status: 200,
+      headers: {
+        "Content-Type": type,
+      },
+    });
+  } catch (err) {
+    console.error("Error reading image:", err);
+    return new NextResponse("Not found", { status: 404 });
+  }
+}


### PR DESCRIPTION
## Summary
- serve tool image files from Upload directory via new API route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ccd6272883239924279324083409