### PR TITLE
Update tool image URL

### DIFF
--- a/src/app/(toolsList)/components/ToolsImageManager.tsx
+++ b/src/app/(toolsList)/components/ToolsImageManager.tsx
@@ -7,6 +7,7 @@ import {
   listToolImages,
   uploadToolImage,
   deleteToolImage,
+  toolImageUrl,
 } from "../services/toolImages";
 import { Box, Fieldset } from "@mantine/core";
 
@@ -41,7 +42,7 @@ export default function ToolsImageManager({ asset }: Props) {
             {images.map((name: string) => (
               <div key={name}>
                 <Image
-                  src={`/tool-images/${name}`}
+                  src={toolImageUrl(asset, name)}
                   alt={name}
                   width={150}
                   height={150}

--- a/src/app/(toolsList)/services/toolImages.ts
+++ b/src/app/(toolsList)/services/toolImages.ts
@@ -1,5 +1,9 @@
 import { http } from "@/services/http-service";
 
+export function toolImageUrl(asset: string, filename: string) {
+  return `/api/toolsdata/${asset}/images/${filename}`;
+}
+
 export async function listToolImages(asset: string) {
   const res = await http.get(`/toolsdata/${asset}/images`);
   return res.data;


### PR DESCRIPTION
## Summary
- fix `ToolsImageManager` to use `/api` path for images
- expose `toolImageUrl` helper for building image URLs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854cce31c808323bdc14376c6d8954b