### PR TITLE
Fix image deletion validation

### DIFF
--- a/src/app/api/toolsdata/[asset]/images/route.ts
+++ b/src/app/api/toolsdata/[asset]/images/route.ts
@@ -53,7 +53,11 @@ export async function DELETE(request: NextRequest) {
   try {
     const filename = request.nextUrl.searchParams.get("filename");
     if (!filename) return new Response("filename required", { status: 400 });
-    await fs.unlink(path.join(IMAGE_DIR, filename));
+    const filePath = path.join(IMAGE_DIR, filename);
+    if (!path.resolve(filePath).startsWith(IMAGE_DIR)) {
+      return new Response("invalid filename", { status: 400 });
+    }
+    await fs.unlink(filePath);
     return new Response("deleted", { status: 200 });
   } catch (error) {
     console.error("Error deleting image:", error);


### PR DESCRIPTION
## Summary
- ensure deletion target path is inside IMAGE_DIR
- return 400 for invalid filename

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854cce6aba08323b52046082cc9793b